### PR TITLE
Fix xpath path for tour field

### DIFF
--- a/custom-addons/tour_booking/views/product_template_views.xml
+++ b/custom-addons/tour_booking/views/product_template_views.xml
@@ -5,7 +5,7 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='general_information']" position="inside">
+            <xpath expr="//page[@name='general_information']/group" position="inside">
                 <field name="es_tour"/>
             </xpath>
         </field>


### PR DESCRIPTION
## Summary
- fix XPath expression in product template view to locate General Information page

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856128a074c8331a1ca9a36c45435c8