### PR TITLE
Fix sale order line view reference

### DIFF
--- a/custom-addons/tour_booking/views/sale_order_views.xml
+++ b/custom-addons/tour_booking/views/sale_order_views.xml
@@ -3,7 +3,11 @@
     <record id="view_sale_order_line_form_inherit_tour" model="ir.ui.view">
         <field name="name">sale.order.line.form.inherit.tour</field>
         <field name="model">sale.order.line</field>
-        <field name="inherit_id" ref="sale.view_order_line_form"/>
+        <!-- In Odoo 18 the sales order line form view moved to the
+             `sale_management` module.  The old `sale.view_order_line_form`
+             reference no longer exists which caused a failure during module
+             installation.  Use the new external identifier instead. -->
+        <field name="inherit_id" ref="sale_management.view_order_line_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="after">
                 <field name="fecha_reserva" attrs="{'invisible': [('product_id.es_tour', '=', False)]}"/>


### PR DESCRIPTION
## Summary
- fix sales order line form inheritance for Odoo 18

## Testing
- `python -m py_compile custom-addons/tour_booking/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685622fedd288331abd576abc65e2581